### PR TITLE
Fix hoofdlettergebruik gmx:Anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <section id="sotd">
       <p>Versie 2.0.0 van het Nederlands metadataprofiel voor services is
         ingegaan op 9 november 2017. Versie 2.0.0 kent een aantal aanpassingen,
-        waarbij introductie van het gebruik van &lt;gmx:anchor&gt; het meest in
+        waarbij introductie van het gebruik van &lt;gmx:Anchor&gt; het meest in
         het oog springt. De voorgaande versie (v1.2.1) wordt nog tot 19 december 2019
         ondersteund.</p>
         <section>
@@ -64,7 +64,7 @@
                   19139:2007
                 </li>
                 <li>Diverse wijzigingen met betrekking tot identificatie van
-                  objecten (introductie gmx:anchor)</li>
+                  objecten (introductie gmx:Anchor)</li>
               </ul>
             </td>
           </tr>
@@ -370,9 +370,9 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
           bijvoorbeeld een Nederlandse vertaling.</p>
         <aside class="example" title="Trefwoord verwijzing met Anchor">
           <pre><code>&lt;gmd:keyword&gt;
-  &lt;gmx:anchor xlink:href="http://inspire.ec.europa.eu/theme/mf"&gt;
+  &lt;gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/mf"&gt;
     Meteorologische geografische kenmerken
-    &lt;/gmx:anchor&gt;
+    &lt;/gmx:Anchor&gt;
 &lt;/gmd:keyword&gt;</code></pre>
         </aside>
       </section>
@@ -1337,10 +1337,10 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
                 <td>Anchor, domein: DataLicenties</td>
                 <td>
                   <pre><code>&lt;otherConstraints&gt;
-  &lt;gmx:anchor
+  &lt;gmx:Anchor
     xlink:href="https://creativecommons.org/
       publicdomain/mark/*/deed.nl"&gt;
-      Geen beperkingen&lt;/gmx:anchor&gt;
+      Geen beperkingen&lt;/gmx:Anchor&gt;
 &lt;/otherConstraints&gt;</code></pre>
                 </td>
               </tr>
@@ -1348,11 +1348,11 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
                 <td>Anchor, domein: ConditionsApplyingToAccessAndUse</td>
                 <td>
                   <pre><code>&lt;otherConstraints&gt;
- &lt;gmx:anchor
+ &lt;gmx:Anchor
     xlink:href="http://inspire.ec.europa.eu/metadata-codelist
       /ConditionsApplyingToAccessAndUse/noConditionsApply"&gt;
       Geen beperkingen
-  &lt;/gmx:anchor&gt;
+  &lt;/gmx:Anchor&gt;
 &lt;/otherConstraints&gt;</code></pre>
                 </td>
               </tr>
@@ -1360,11 +1360,11 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
                 <td>Anchor, domein: LimitationsOnPublicAccess</td>
                 <td>
                   <pre><code>&lt;otherConstraints&gt;
-  &lt;gmx:anchor
+  &lt;gmx:Anchor
     xlink:href="http://inspire.ec.europa.eu/metadata-codelist/
       LimitationsOnPublicAccess/noLimitations"&gt;
       Geen beperkingen
-  &lt;/gmx:anchor&gt;
+  &lt;/gmx:Anchor&gt;
 &lt;/otherConstraints&gt;</code></pre>
                 </td>
               </tr>
@@ -1396,10 +1396,10 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
           gmxCodelists.xml#MD_RestrictionCode"/&gt;
     &lt;/accessConstraints&gt;   
     &lt;otherConstraints&gt;
-      &lt;gmx:anchor
+      &lt;gmx:Anchor
         xlink:href="https://creativecommons.org/publicdomain/mark/*/deed.nl"&gt;
           Geen beperkingen
-      &lt;/gmx:anchor&gt;
+      &lt;/gmx:Anchor&gt;
     &lt;/otherConstraints&gt;
   &lt;/MD_LegalConstraints&gt;
 &lt;/resourceConstraints&gt; 
@@ -1415,17 +1415,17 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
           gmxCodelists.xml#MD_RestrictionCode"/&gt;
     &lt;/accessConstraints&gt;   
     &lt;otherConstraints&gt;
-      &lt;gmx:anchor
+      &lt;gmx:Anchor
         xlink:href="https://creativecommons.org/publicdomain/mark/*/deed.nl"&gt;
           Geen beperkingen
-      &lt;/gmx:anchor&gt;
+      &lt;/gmx:Anchor&gt;
     &lt;/otherConstraints&gt;
     &lt;otherConstraints&gt;
-      &lt;gmx:anchor
+      &lt;gmx:Anchor
         xlink:href="http://inspire.ec.europa.eu/metadata-codelist
           /ConditionsApplyingToAccessAndUse/noConditionsApply"&gt;
           Geen beperkingen
-      &lt;/gmx:anchor&gt;
+      &lt;/gmx:Anchor&gt;
     &lt;/otherConstraints&gt;
   &lt;/MD_LegalConstraints&gt;
 &lt;/resourceConstraints&gt;
@@ -1438,11 +1438,11 @@ http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd</a></td>
           gmxCodelists.xml#MD_RestrictionCode"/&gt;
     &lt;/accessConstraints&gt;
     &lt;otherConstraints&gt;
-      &lt;gmx:anchor
+      &lt;gmx:Anchor
         xlink:href="http://inspire.ec.europa.eu/metadata-codelist/
           LimitationsOnPublicAccess/noLimitations"&gt;
           Geen beperkingen
-      &lt;/gmx:anchor&gt;
+      &lt;/gmx:Anchor&gt;
     &lt;/otherConstraints&gt;
   &lt;/MD_LegalConstraints&gt;
 &lt;/resourceConstraints&gt;  


### PR DESCRIPTION
**Nota bene**: moet dit op gh-pages branch gefixed worden? Voor mij is niet helemaal duidelijk welke branch de actuele versie bevat (version-2.0.0 lijkt ouder te zijn)